### PR TITLE
Support for password authentication for connecting to a master.

### DIFF
--- a/flags.cc
+++ b/flags.cc
@@ -44,6 +44,9 @@ DEFINE_string(ripple_server_name, "",
 DEFINE_string(ripple_master_user, "root",
               "Connect to master using this user");
 
+DEFINE_string(ripple_master_password, "",
+              "Connect to master using this password");
+
 DEFINE_string(ripple_master_protocol, "",
               "Connect to master using this protcol "
               "(if none set using mysql default)");

--- a/flags.h
+++ b/flags.h
@@ -29,6 +29,7 @@ DECLARE_string(ripple_server_type);
 
 DECLARE_int32(ripple_master_port);
 DECLARE_string(ripple_master_user);
+DECLARE_string(ripple_master_password);
 DECLARE_string(ripple_master_protocol);
 DECLARE_string(ripple_master_address);
 DECLARE_bool(ripple_master_compressed_protocol);

--- a/management.proto
+++ b/management.proto
@@ -110,6 +110,7 @@ message MasterInfo {
     google.protobuf.BoolValue semi_sync_slave_reply_enabled = 5;
     google.protobuf.BoolValue compressed_protocol = 6;
     google.protobuf.DoubleValue heartbeat_period = 7;
+    google.protobuf.StringValue password = 8;
 }
 
 message MasterStatus {

--- a/manager.cc
+++ b/manager.cc
@@ -121,6 +121,8 @@ void Manager::FillMasterStatus(ripple_proto::MasterStatus *master_status) {
         ->set_value(connection.GetHost());
     master_status->mutable_master_info()->mutable_user()
         ->set_value(connection.GetUser());
+    master_status->mutable_master_info()->mutable_password()
+        ->set_value(connection.GetPassword());
     master_status->mutable_master_info()->mutable_port()
         ->set_value(connection.GetPort());
     master_status->mutable_master_info()->mutable_protocol()
@@ -131,6 +133,8 @@ void Manager::FillMasterStatus(ripple_proto::MasterStatus *master_status) {
         ->set_value(session.GetHost());
     master_status->mutable_master_info()->mutable_user()
         ->set_value(session.GetUser());
+    master_status->mutable_master_info()->mutable_password()
+        ->set_value(session.GetPassword());
     master_status->mutable_master_info()->mutable_port()
         ->set_value(session.GetPort());
     master_status->mutable_master_info()->mutable_protocol()
@@ -246,6 +250,9 @@ void Manager::ChangeMaster(const ripple_proto::MasterInfo *master_info,
   }
   if (master_info->has_user()) {
     session.SetUser(master_info->user().value());
+  }
+  if (master_info->has_password()) {
+    session.SetPassword(master_info->password().value());
   }
   if (master_info->has_port()) {
     session.SetPort(master_info->port().value());

--- a/mysql_client_connection.cc
+++ b/mysql_client_connection.cc
@@ -80,7 +80,8 @@ ClientConnection::Connect(const char *name,
                           const char *host,
                           int port,
                           const char *protocol,
-                          const char *user) {
+                          const char *user,
+                          const char *password) {
   ClearError();
 
   {
@@ -109,7 +110,6 @@ ClientConnection::Connect(const char *name,
   user_ = user;
   protocol_ = protocol;
 
-  const char *passwd = nullptr;
   const char *db = nullptr;
   const char *socket = nullptr;
   int flags = 0;
@@ -122,7 +122,7 @@ ClientConnection::Connect(const char *name,
   mysql_options(mysql_.get(), MYSQL_OPT_PROTOCOL, (char*) &opt_protocol);
 
   MYSQL *res = mysql_real_connect(
-      mysql_.get(), host, user, passwd, db, port, socket, flags);
+      mysql_.get(), host, user, password, db, port, socket, flags);
 
   if (res == nullptr) {
     SetError(std::string("Failed to connect: ").

--- a/mysql_client_connection.h
+++ b/mysql_client_connection.h
@@ -59,7 +59,8 @@ class ClientConnection : public Connection {
                        const char *host,
                        int port,
                        const char *protocol,
-                       const char *user);
+                       const char *user,
+                       const char *password);
 
   // Read a packet.
   // The returned packet is valid until next call.
@@ -137,6 +138,7 @@ class ClientConnection : public Connection {
   // These methods are for monitoring
   std::string GetHost() const override { return host_; }
   std::string GetUser() const { return user_; }
+  std::string GetPassword() const { return password_; }
   uint16_t GetPort() const override { return port_; }
   std::string GetProtocol() const { return protocol_; }
 
@@ -156,6 +158,7 @@ class ClientConnection : public Connection {
   uint16_t port_;
   std::string protocol_;
   std::string user_;
+  std::string password_;
 
   bool FetchMysqlVariant();
   bool ExecuteSetHeartbeatPeriod(double seconds);

--- a/mysql_master_session.cc
+++ b/mysql_master_session.cc
@@ -39,6 +39,7 @@ MasterSession::MasterSession(Binlog *binlog,
       port_(FLAGS_ripple_master_port),
       protocol_(FLAGS_ripple_master_protocol),
       user_(FLAGS_ripple_master_user),
+      password_(FLAGS_ripple_master_password),
       compressed_protocol_(FLAGS_ripple_master_compressed_protocol),
       heartbeat_period_(FLAGS_ripple_master_heartbeat_period),
       connection_attempt_counter_(0),
@@ -115,7 +116,8 @@ bool MasterSession::Connect() {
                           host_.c_str(),
                           port_,
                           protocol_.c_str(),
-                          user_.c_str()) &&
+                          user_.c_str(),
+                          password_.c_str()) &&
       connection_.FetchServerVersion() &&
       connection_.FetchServerId()) {
     connection_.FetchVariable("server_name", &server_name_);
@@ -162,7 +164,8 @@ bool MasterSession::Connect() {
   LOG(WARNING)
       << "Failed to connected to"
       << " host: " << host_
-      << ", port: " << port_;
+      << ", port: " << port_
+      << ", err: " << connection_.GetLastErrorMessage();
   connection_.Disconnect();
   return false;
 }

--- a/mysql_master_session.h
+++ b/mysql_master_session.h
@@ -80,6 +80,7 @@ class MasterSession : public ThreadedSession {
   void SetPort(int port) { port_ = port; }
   void SetProtocol(const std::string& protocol) { protocol_ = protocol; }
   void SetUser(const std::string& user) { user_ = user; }
+  void SetPassword(const std::string& password) { password_ = password; }
   void SetCompressedProtocol(bool onoff) { compressed_protocol_ = onoff; }
   void SetHeartbeatPeriod(double period) { heartbeat_period_ = period; }
 
@@ -87,6 +88,7 @@ class MasterSession : public ThreadedSession {
   int GetPort() const { return port_; }
   std::string GetProtocol() const { return protocol_; }
   std::string GetUser() const { return user_; }
+  std::string GetPassword() const { return password_; }
   bool GetCompressedProtocol() const { return compressed_protocol_; }
   double GetHeartbeatPeriod() const { return heartbeat_period_; }
 
@@ -103,6 +105,7 @@ class MasterSession : public ThreadedSession {
   int port_;
   std::string protocol_;
   std::string user_;
+  std::string password_;
   bool compressed_protocol_;
   double heartbeat_period_;
 


### PR DESCRIPTION
With this rippled is able to connect to a password protected account on a MySQL 5.7 server.

- I did not test if connecting w/o password is still possible
- I'm not sure if the change in `MasterInfo` is correct (I assumed the best practice is to add entries in the end instead of inserting and re-numbering)

Issue: #6 