### PR TITLE
Authenticate client connections with mysql_native_password

### DIFF
--- a/flags.cc
+++ b/flags.cc
@@ -41,6 +41,10 @@ DEFINE_string(ripple_server_name, "",
               "Server name that ripple sets when connecting to master "
               "and exposes in the server_name variable");
 
+DEFINE_string(ripple_server_password_hash, "",
+              "Password hash in mysql_native_password format to authenticate "
+              "client connections. Without leading *");
+
 DEFINE_string(ripple_master_user, "root",
               "Connect to master using this user");
 

--- a/flags.h
+++ b/flags.h
@@ -26,6 +26,7 @@ DECLARE_string(ripple_rw_rpc_users);
 DECLARE_string(ripple_server_ports);
 DECLARE_string(ripple_server_address);
 DECLARE_string(ripple_server_type);
+DECLARE_string(ripple_server_password_hash);
 
 DECLARE_int32(ripple_master_port);
 DECLARE_string(ripple_master_user);


### PR DESCRIPTION
- This only allows one password hash
- This does NOT verify the username
- This won't work for clients that ignore the default authentication method send by the server and are not using `mysql_native_password` by default. See also: https://github.com/vitessio/vitess/issues/4332 and https://bugs.mysql.com/bug.php?id=93044 . This affects MySQL 8.0 clients as 8.0 always tries to authenticate with `caching_sha2_password`. The solution is to implement `caching_sha2_password` over TLS and/or implement `AuthSwitchRequest`.

Issue: #6

Example use:
```
$ ./my sql -BNe "SELECT PASSWORD('foobar')"
*9B500343BC52E2911172EB52AE5CF4847604C6E5
$ rippled -ripple_server_password_hash=9B500343BC52E2911172EB52AE5CF4847604C6E5
```
