### PR TITLE
Handle Authentication Method Mismatch for MySQL 8.0

### DIFF
--- a/mysql_protocol.h
+++ b/mysql_protocol.h
@@ -48,6 +48,11 @@ class Protocol {
   virtual bool GetEventChecksums() const { return event_checksums_; }
 
   virtual bool Authenticate();
+  virtual bool ValidateNativeHash(const char *authdata, int authdata_len,
+                                  const char *slave_pwhash,
+                                  unsigned char *scramble);
+  virtual bool SendAuthSwitchRequest(const char *plugin, unsigned char *data,
+                                     size_t data_len);
   virtual bool SendOK();
   virtual bool SendEOF();
   virtual bool SendERR(int code, const char* sqlstate, const char* msg);


### PR DESCRIPTION
This is on top of #7 
Issue: #6 

See also: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase.html#sect_protocol_connection_phase_auth_method_mismatch_method_change

This ensures this happens with MySQL 8.0:
-> ServerGreeting(default_auth=mysql_native_password)
<- Login(auth=caching_sha2)
-> AuthSwitchRequest(auth=mysql_native_password)
<- AuthSwitchResponse(auth data for native auth)